### PR TITLE
fix the bug of dynamic adding job in cron.go

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -147,6 +147,7 @@ func (c *Cron) run() {
 		case <-c.stop:
 			return // terminate go-routine.
 		}
+		now = time.Now().Local()
 	}
 }
 


### PR DESCRIPTION
fix the bug of dynamic adding job ( the case: c.running ==true ), the calculation of new time must be done before the next round for loop.