### PR TITLE
Feature/use context to control goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+  - 1.x
+script: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Gron provides a clear syntax for writing and deploying cron jobs.
 - Customizable Job Type.
 - Customizable Schedule.
 
-## Different to origin gron
+## Different to origin
 
 Most features and interfaces are as same as origin repository, but also introduces one new method to Cron, which `StopAfterJobDone` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which handler does not including in library). After interrupt signal handling, stopping cron gracefully via `StopAfterJobDone`, prevent bundle of processing job stop inappropriately.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # gron
-[![Build Status](https://semaphoreci.com/api/v1/roylee0704/gron/branches/master/badge.svg)](https://semaphoreci.com/roylee0704/gron)
-[![Go Report Card](https://goreportcard.com/badge/github.com/roylee0704/gron)](https://goreportcard.com/report/github.com/roylee0704/gron)
-[![GoDoc](https://godoc.org/github.com/roylee0704/gron?status.svg)](https://godoc.org/github.com/roylee0704/gron)
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/fred07/gron)](https://goreportcard.com/report/github.com/fred07/gron)
 
 Gron provides a clear syntax for writing and deploying cron jobs.
 
@@ -19,6 +18,7 @@ $ go get github.com/roylee0704/gron
 ```
 
 ## Usage
+
 Create `schedule.go`
 
 ```go
@@ -39,10 +39,9 @@ func main() {
 }
 ```
 
-#### Schedule Parameters
+### Schedule Parameters
 
 All scheduling is done in the machine's local time zone (as provided by the Go [time package](http://www.golang.org/pkg/time)).
-
 
 Setup basic periodic schedule with `gron.Every()`.
 
@@ -53,6 +52,7 @@ gron.Every(1*time.Hour)
 ```
 
 Also support `Day`, `Week` by importing `gron/xtime`:
+
 ```go
 import "github.com/roylee0704/gron/xtime"
 
@@ -61,12 +61,14 @@ gron.Every(1 * xtime.Week)
 ```
 
 Schedule to run at specific time with `.At(hh:mm)`
+
 ```go
 gron.Every(30 * xtime.Day).At("00:00")
 gron.Every(1 * xtime.Week).At("23:59")
 ```
 
-#### Custom Job Type
+### Custom Job Type
+
 You may define custom job types by implementing `gron.Job` interface: `Run()`.
 
 For example:
@@ -82,6 +84,7 @@ func (r Reminder) Run() {
 ```
 
 After job has defined, instantiate it and schedule to run in Gron.
+
 ```go
 c := gron.New()
 r := Reminder{ "Feed the baby!" }
@@ -89,7 +92,8 @@ c.Add(gron.Every(8*time.Hour), r)
 c.Start()
 ```
 
-#### Custom Job Func
+### Custom Job Func
+
 You may register `Funcs` to be executed on a given schedule. Gron will run them in their own goroutines, asynchronously.
 
 ```go
@@ -100,8 +104,8 @@ c.AddFunc(gron.Every(1*time.Second), func() {
 c.Start()
 ```
 
+### Custom Schedule
 
-#### Custom Schedule
 Schedule is the interface that wraps the basic `Next` method: `Next(p time.Duration) time.Time`
 
 In `gron`, the interface value `Schedule` has the following concrete types:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,17 @@ Gron provides a clear syntax for writing and deploying cron jobs.
 
 ## Different to origin
 
-Most features and interfaces are as same as origin repository, but also introduces one new feature to Cron, which `GracefullyStop()` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which handler does not including in library). After interrupt signal handling, stopping cron gracefully via `GracefullyStop`, prevent bundle of processing job stop inappropriately.
+Most features and interfaces are as same as origin repository, but also introduces one new feature to Cron, which `GracefullyStop()` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which gron also provide handler for this, check document below). After interrupt signal handling, stopping cron gracefully via `GracefullyStop`, prevent bundle of processing job stop inappropriately.
 
 Second new feature is built in OS signal handler, after calling `HandleSignals()`, and passing target signal, Cron would register signals, while signals interrupt, it's behavior would just like `GracefullyStop()` (which also means not exactly same) that ensure sub-job are finished.
+
+Last one is `StartAndServe()`, this feature makes gron blocking and keep go-routine alive and til it return an error, which that you don't have to create an ugly infinite loop. All you need to do is like `log.Fatal(gron.StartAndServe())`
+
+### Summary of new features
+
+- `GracefullyStop()`
+- `HandleSignals()`
+- `StartAndServe()`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gron provides a clear syntax for writing and deploying cron jobs.
 ## Installation
 
 ```sh
-$ go get github.com/roylee0704/gron
+$ go get github.com/fred07/gron
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ package main
 import (
 	"fmt"
 	"time"
-	"github.com/roylee0704/gron"
+	"github.com/fred07/gron"
 )
 
 func main() {
@@ -54,7 +54,7 @@ gron.Every(1*time.Hour)
 Also support `Day`, `Week` by importing `gron/xtime`:
 
 ```go
-import "github.com/roylee0704/gron/xtime"
+import "github.com/fred07/gron/xtime"
 
 gron.Every(1 * xtime.Day)
 gron.Every(1 * xtime.Week)
@@ -122,8 +122,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/roylee0704/gron"
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fred07/gron"
+	"github.com/fred07/gron/xtime"
 )
 
 type PrintJob struct{ Msg string }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ gron.Every(1 * xtime.Week).At("23:59")
 
 ### Custom Job Type
 
-You may define custom job types by implementing `gron.Job` interface: `Run()`.
+You may define custom job types by implementing `gron.Job` interface: `Run(wg *sync.WaitGroup)`.
 
 For example:
 
@@ -93,7 +93,7 @@ type Reminder struct {
 	Msg string
 }
 
-func (r Reminder) Run() {
+func (r Reminder) Run(wg *sync.WaitGroup) {
   fmt.Println(r.Msg)
 }
 ```
@@ -130,7 +130,7 @@ In `gron`, the interface value `Schedule` has the following concrete types:
 
 For more info, checkout `schedule.go`.
 
-### Serve like a server
+### Serve like a daemon
 
 In real case, you may need a infinite `for` loop to keep main goroutine alive, in fact, you can use `StartAndServe()` to do that.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # gron
 
+[![Build Status](https://travis-ci.com/Fred07/gron.svg?branch=master)](https://travis-ci.com/Fred07/gron)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fred07/gron)](https://goreportcard.com/report/github.com/fred07/gron)
 
 Gron provides a clear syntax for writing and deploying cron jobs.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Gron provides a clear syntax for writing and deploying cron jobs.
 
 ## Different to origin
 
-Most features and interfaces are as same as origin repository, but also introduces one new method to Cron, which `StopAfterJobDone` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which handler does not including in library). After interrupt signal handling, stopping cron gracefully via `StopAfterJobDone`, prevent bundle of processing job stop inappropriately.
+Most features and interfaces are as same as origin repository, but also introduces one new feature to Cron, which `GracefullyStop()` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which handler does not including in library). After interrupt signal handling, stopping cron gracefully via `GracefullyStop`, prevent bundle of processing job stop inappropriately.
+
+Second new feature is built in OS signal handler, after calling `HandleSignals()`, and passing target signal, Cron would register signals, while signals interrupt, it's behavior would just like `GracefullyStop()` (which also means not exactly same) that ensure sub-job are finished.
 
 ## Installation
 
@@ -119,6 +121,20 @@ In `gron`, the interface value `Schedule` has the following concrete types:
 - **atSchedule**. reoccurs every period p, at time components(hh:mm).
 
 For more info, checkout `schedule.go`.
+
+### Serve like a server
+
+In real case, you may need a infinite `for` loop to keep main goroutine alive, in fact, you can use `StartAndServe()` to do that.
+
+`StartAndServe()` is the method to start cron and keeping process there like a server.
+
+```go
+c := gron.New()
+c.AddFunc(gron.Every(1*time.Second), func() {
+	fmt.Println("runs every second")
+})
+c.StartAndServe()
+```
 
 ### Full Example
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Gron provides a clear syntax for writing and deploying cron jobs.
 - Customizable Job Type.
 - Customizable Schedule.
 
+## Different to origin gron
+
+Most features and interfaces are as same as origin repository, but also introduces one new method to Cron, which `StopAfterJobDone` make cron has ability to hold the process, stop creating new child goroutine, and ensure sub-job is finished before main goroutine close. This benefit to the scenarios like handling `os.Signal` including `SIGINT`, `SIGTERM` (which handler does not including in library). After interrupt signal handling, stopping cron gracefully via `StopAfterJobDone`, prevent bundle of processing job stop inappropriately.
+
 ## Installation
 
 ```sh

--- a/cron.go
+++ b/cron.go
@@ -151,7 +151,7 @@ func (c *Cron) run() {
 				}
 				entry.Prev = now
 				entry.Next = entry.Schedule.Next(now)
-				go entry.Job.Run(wg)
+				go entry.Job.Run(c.wg)
 			}
 		case e := <-c.add:
 			e.Next = e.Schedule.Next(time.Now())

--- a/cron.go
+++ b/cron.go
@@ -164,7 +164,7 @@ func (c *Cron) run() {
 }
 
 // Entries returns cron etn
-func (c Cron) Entries() []*Entry {
+func (c *Cron) Entries() []*Entry {
 	return c.entries
 }
 

--- a/cron.go
+++ b/cron.go
@@ -83,6 +83,12 @@ func (c *Cron) HandleSignals(signals ...os.Signal) {
 	signal.Notify(c.sigChan, signals...)
 }
 
+// StartAndServe serve cron like a eternal process
+func (c *Cron) StartAndServe() {
+	c.running = true
+	c.run()
+}
+
 // Start signals cron instant c to get up and running.
 func (c *Cron) Start() {
 	c.running = true

--- a/cron.go
+++ b/cron.go
@@ -122,8 +122,9 @@ func (c *Cron) Stop() {
 	c.stop <- struct{}{}
 }
 
-// StopAfterJobDone halts cron after running jobs are finished
-func (c *Cron) StopAfterJobDone() {
+// GracefullyStop halts cron after running jobs are finished
+func (c *Cron) GracefullyStop() {
+
 	c.stopAndWait()
 	c.stop <- struct{}{}
 }

--- a/cron.go
+++ b/cron.go
@@ -1,6 +1,8 @@
 package gron
 
 import (
+	"os"
+	"os/signal"
 	"sort"
 	"sync"
 	"time"
@@ -59,14 +61,26 @@ type Cron struct {
 	add     chan *Entry
 	stop    chan struct{}
 	wg      sync.WaitGroup
+	sigChan chan os.Signal
 }
 
 // New instantiates new Cron instant c.
 func New() *Cron {
 	return &Cron{
-		stop: make(chan struct{}),
-		add:  make(chan *Entry),
+		stop:    make(chan struct{}),
+		add:     make(chan *Entry),
+		sigChan: make(chan os.Signal),
 	}
+}
+
+// HandleSignals to deside what signal should be aware
+func (c *Cron) HandleSignals(signals ...os.Signal) {
+	if len(signals) == 0 {
+		return
+	}
+
+	// sigChan would not receive signals without register
+	signal.Notify(c.sigChan, signals...)
 }
 
 // Start signals cron instant c to get up and running.
@@ -110,12 +124,16 @@ func (c *Cron) Stop() {
 
 // StopAfterJobDone halts cron after running jobs are finished
 func (c *Cron) StopAfterJobDone() {
+	c.stopAndWait()
+	c.stop <- struct{}{}
+}
+
+func (c *Cron) stopAndWait() {
 	if !c.running {
 		return
 	}
 	c.running = false
 	c.wg.Wait()
-	c.stop <- struct{}{}
 }
 
 var after = time.After
@@ -154,6 +172,9 @@ func (c *Cron) run() {
 				c.wg.Add(1)
 				go entry.Job.Run(&c.wg)
 			}
+		case <-c.sigChan:
+			c.stopAndWait()
+			return
 		case e := <-c.add:
 			e.Next = e.Schedule.Next(time.Now())
 			c.entries = append(c.entries, e)

--- a/cron_test.go
+++ b/cron_test.go
@@ -109,7 +109,7 @@ func TestJobsDontRunAfterStop(t *testing.T) {
 	}
 }
 
-func TestJobFinishedBeforeStop(t *testing.T) {
+func TestGracefullyStop(t *testing.T) {
 	failCh := make(chan bool, 1)
 	successCh := make(chan bool, 1)
 
@@ -121,7 +121,7 @@ func TestJobFinishedBeforeStop(t *testing.T) {
 			successCh <- true                          // success signal
 		})
 		time.Sleep(time.Duration(2) * time.Second) // prevent stop too fast
-		cron.StopAfterJobDone()                    // call stop
+		cron.GracefullyStop()                      // call stop
 		failCh <- true                             // fail signal
 	}()
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -105,7 +106,6 @@ func TestJobsDontRunAfterStop(t *testing.T) {
 		// no job has run
 	case <-wait(wg):
 		t.FailNow()
-
 	}
 }
 
@@ -113,28 +113,55 @@ func TestJobFinishedBeforeStop(t *testing.T) {
 	failCh := make(chan bool, 1)
 	successCh := make(chan bool, 1)
 
-	go func(successCh chan bool, failCh chan bool) {
-	loop:
-		for {
-			select {
-			case <-successCh:
-				break loop
-			case <-failCh:
-				t.FailNow()
-			default:
-			}
-		}
-	}(successCh, failCh)
+	go func() {
+		cron := New()
+		cron.Start()
+		cron.AddFunc(Every(2*time.Second), func() {
+			time.Sleep(time.Duration(1) * time.Second) // make job running while stopping
+			successCh <- true                          // success signal
+		})
+		time.Sleep(time.Duration(2) * time.Second) // prevent stop too fast
+		cron.StopAfterJobDone()                    // call stop
+		failCh <- true                             // fail signal
+	}()
 
+loop:
+	for {
+		select {
+		case <-successCh:
+			break loop
+		case <-failCh:
+			t.FailNow()
+		default:
+		}
+	}
+}
+
+func TestInterruptSingal(t *testing.T) {
+	successCh := make(chan bool, 1)
 	cron := New()
-	cron.Start()
-	cron.AddFunc(Every(2*time.Second), func() {
-		time.Sleep(time.Duration(1) * time.Second) // make job running while stopping
-		successCh <- true                          // success signal
-	})
-	time.Sleep(time.Duration(2) * time.Second) // prevent stop too fast
-	cron.StopAfterJobDone()                    // call stop
-	failCh <- true                             // fail signal
+
+	go func() {
+		pid := syscall.Getpid()
+		cron.Start()
+		cron.HandleSignals(syscall.SIGINT, syscall.SIGTERM)
+		cron.AddFunc(Every(1*time.Second), func() {
+			time.Sleep(time.Duration(1) * time.Second)
+			successCh <- true
+		})
+		time.Sleep(time.Duration(1) * time.Second)
+		syscall.Kill(pid, syscall.SIGINT)
+	}()
+
+loop:
+	for {
+		select {
+		case <-successCh:
+			break loop
+		case <-time.After(time.Duration(5) * time.Second):
+			t.FailNow()
+		}
+	}
 
 }
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Most test jobs scheduled to run at 1 second mark.
-// Test expects to fail after OneSecond: 1.01 seconds.
-const OneSecond = 1*time.Second + 10*time.Millisecond
+// Test expects to fail after OneSecond: 1.05 seconds.
+const OneSecond = 1*time.Second + 50*time.Millisecond
 
 // start cron, stop cron successfully.
 func TestNoEntries(t *testing.T) {
@@ -116,11 +116,11 @@ func TestGracefullyStop(t *testing.T) {
 	go func() {
 		cron := New()
 		cron.Start()
-		cron.AddFunc(Every(2*time.Second), func() {
-			time.Sleep(time.Duration(1) * time.Second) // make job running while stopping
+		cron.AddFunc(Every(3*time.Second), func() {
+			time.Sleep(time.Duration(2) * time.Second) // make job running while stopping
 			successCh <- true                          // success signal
 		})
-		time.Sleep(time.Duration(2) * time.Second) // prevent stop too fast
+		time.Sleep(time.Duration(4) * time.Second) // prevent stop too fast
 		cron.GracefullyStop()                      // call stop
 		failCh <- true                             // fail signal
 	}()
@@ -145,11 +145,11 @@ func TestInterruptSingal(t *testing.T) {
 		pid := syscall.Getpid()
 		cron.Start()
 		cron.HandleSignals(syscall.SIGINT, syscall.SIGTERM)
-		cron.AddFunc(Every(1*time.Second), func() {
-			time.Sleep(time.Duration(1) * time.Second)
+		cron.AddFunc(Every(3*time.Second), func() {
+			time.Sleep(time.Duration(2) * time.Second)
 			successCh <- true
 		})
-		time.Sleep(time.Duration(1) * time.Second)
+		time.Sleep(time.Duration(4) * time.Second)
 		syscall.Kill(pid, syscall.SIGINT)
 	}()
 
@@ -158,7 +158,7 @@ loop:
 		select {
 		case <-successCh:
 			break loop
-		case <-time.After(time.Duration(5) * time.Second):
+		case <-time.After(time.Duration(6) * time.Second):
 			t.FailNow()
 		}
 	}

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fred07/gron/xtime"
 )
 
 // Most test jobs scheduled to run at 1 second mark.

--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -27,16 +28,19 @@ func main() {
 		printBar  = printJob{"Bar"}
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	c := gron.New()
 
 	c.AddFunc(gron.Every(1*time.Hour), func() {
 		fmt.Println("Every 1 hour")
 	})
-	c.Start()
+	c.Start(ctx)
 
 	c.AddFunc(weekly, func() { fmt.Println("Every week") })
 	c.Add(daily.At("12:30"), printFoo)
-	c.Start()
+	c.Start(ctx)
 
 	// Jobs may also be added to a running Cron
 	c.Add(monthly, printBar)

--- a/example/main.go
+++ b/example/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/fred07/gron"
@@ -10,7 +11,7 @@ import (
 
 type printJob struct{ Msg string }
 
-func (p printJob) Run() {
+func (p printJob) Run(wg *sync.WaitGroup) {
 	fmt.Println(p.Msg)
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/roylee0704/gron"
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fred07/gron"
+	"github.com/fred07/gron/xtime"
 )
 
 type printJob struct{ Msg string }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/fred07/gron
+
+go 1.14

--- a/schedule.go
+++ b/schedule.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fred07/gron/xtime"
 )
 
 // Schedule is the interface that wraps the basic Next method.

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fred07/gron/xtime"
 )
 
 func TestPeriodicAtNext(t *testing.T) {

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-## Design Goal
+# Design Goal
 
 - No delay job. Next schedule for a particular job shall not be delayed for its processing time. For example: Every(1).Minute() ensures tasks run at 10:01, 10:02, 10:03, but not 10:01+processing.
 - Every(second,minute,hour,day,week).At(hh:mm)
@@ -6,23 +6,30 @@
 ## Design Specs
 
 ### CRON
+
 An ADT that maintains a sequence of chronologically sorted entries. Cron keeps track of any number of entries, invoking the associated func as specified by the schedule. It may also be started, stopped and the entries may be inspected.
 
 - **Start()**. Signals 'start' to get cron instant up & running.
 - **Add(schedule, job)**. Signals `add` to add entry(schedule, job) to cron instant.
 - **Stop()**. Signals `stop` to halt cron instant's processing. Bear in mind that (child go-routines) running jobs will be halted as well.
+- **StopAfterJobDone**. Signals `stop after job done` to halt cron processing. Different to `stop` signal, running child go-routines would finish normally before cron stop.
 - **Clear()**. Clear all entries from queue.
 - **run()**. Core functionality, run indefinitely(go-routine), forking out child go-routine: one for each job, multiplexing different channels/signals.
 
 ### SCHEDULE
+
 An interface which wraps `Next(time)` method.
+
 - **Next(time)**. Deduces next occurring schedule w.r.t time instant t.
 
 ### JOB
+
 An interface which wraps `Run` method.
-- **Run()**. To execute the underlying func.
+
+- **Run(wg *sync.WaitGroup)**. To execute the underlying func.
 
 ### ENTRY
+
 An ADT consists of a schedule and job to be run on that schedule. Also known as wrapper to `schedule` and `job`.
 
 It keep tracks on the following states: `schedule`, `job`, `next`, `prev`.
@@ -30,6 +37,7 @@ It keep tracks on the following states: `schedule`, `job`, `next`, `prev`.
 ## Detailed Design
 
 ### Cron: run() -- **core**
+
 1. Sort entries chronologically.
 2. Earliest entry be taken as the next triggering point.
 3. Multiplexing of blocking channels/signals, that includes:
@@ -39,16 +47,19 @@ It keep tracks on the following states: `schedule`, `job`, `next`, `prev`.
 4. Repeat 1. until `stop` is signaled.
 
 ### Entry: Sorted entry-slice
+
 Entry slice implements sort package, chronologically.
 
-
 ### Schedule: periodicSchedule
+
 A periodic schedule which occurs periodically: `t + period`
+
 - **Every(period)**. Returns a periodicSchedule instant.
 
-
 ## Testing
+
 Given a queue of scheduled entries. Test that:
+
 - order of execution. add entries in reverse order, after one run, expects all entries are sorted accordingly.
 - execution. ensure all entries are being executed.
 - test concurrency adding.


### PR DESCRIPTION
Remove `HandleSignals()`

Add context to the gron, and listen to `context.Done()` to trigger `GracefullyStop()`