### PR TITLE
[feat] support cancel job.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Roy Lee <roylee0704@gmail.com>
+Copyright (c) 2023 Roy Lee <roylee0704@gmail.com>, fakeYanss
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Roy Lee <roylee0704@gmail.com>, fakeYanss
+Copyright (c) 2023 Roy Lee <roylee0704@gmail.com>, fakeyanss
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ func main() {
 
 All scheduling is done in the machine's local time zone (as provided by the Go [time package](http://www.golang.org/pkg/time)).
 
-
 Setup basic periodic schedule with `gron.Every()`.
 
 ```go
@@ -100,7 +99,6 @@ c.AddFunc(gron.Every(1*time.Second), func() {
 c.Start()
 ```
 
-
 #### Custom Schedule
 Schedule is the interface that wraps the basic `Next` method: `Next(p time.Duration) time.Time`
 
@@ -110,6 +108,35 @@ In `gron`, the interface value `Schedule` has the following concrete types:
 - **atSchedule**. reoccurs every period p, at time components(hh:mm).
 
 For more info, checkout `schedule.go`.
+
+#### Cancel Job
+You may cancel specified job with a unique jobID.
+
+```go
+type canceledJob struct { // implements of JobWithCancel interface
+	id string
+}
+
+func (j *canceledJob) JobID() {
+	return id
+}
+
+func (j *canceledJob) Run() {
+  fmt.Println("job run")
+}
+
+c := gron.New()
+c.AddFuncWithJobID(gron.Every(1*time.Second), "job-id-1", func() {
+	fmt.Println("runs every second")
+})
+c.AddCancelingJob(Every(1*time.Second), &canceledJob{id: "job-id-2"})
+c.Start()
+
+time.Sleep(5 * time.Second)
+
+c.Cancel("job-id-1")
+c.Cancel("job-id-2")
+```
 
 ### Full Example
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Just add feature of canceling job.
 
 ```sh
 # $ go get github.com/roylee0704/gron
-$ go get github.com/fakeYanss/gron
+$ go get github.com/fakeyanss/gron
 ```
 
 ## Usage
@@ -33,7 +33,7 @@ import (
 	"fmt"
 	"time"
 	// "github.com/roylee0704/gron"
-	"github.com/fakeYanss/gron"
+	"github.com/fakeyanss/gron"
 )
 
 func main() {
@@ -60,7 +60,7 @@ gron.Every(1*time.Hour)
 Also support `Day`, `Week` by importing `gron/xtime`:
 ```go
 // import "github.com/roylee0704/gron/xtime"
-import "github.com/fakeYanss/gron/xtime"
+import "github.com/fakeyanss/gron/xtime"
 
 gron.Every(1 * xtime.Day)
 gron.Every(1 * xtime.Week)
@@ -154,8 +154,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fakeYanss/gron"
-	"github.com/fakeYanss/gron/xtime"
+	"github.com/fakeyanss/gron"
+	"github.com/fakeyanss/gron/xtime"
 )
 
 type printJob struct{ Msg string }

--- a/cron.go
+++ b/cron.go
@@ -206,8 +206,10 @@ func (c *Cron) run() {
 		case e := <-c.add:
 			e.Next = e.Schedule.Next(time.Now())
 			c.entries = append(c.entries, e)
+            now = time.Now().Local()
 		case cancelJobID := <-c.cancel:
 			c.cancelJob(cancelJobID)
+            now = time.Now().Local()
 		case <-c.stop:
 			return // terminate go-routine.
 		}

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fakeYanss/gron/xtime"
 )
 
 // Most test jobs scheduled to run at 1 second mark.

--- a/cron_test.go
+++ b/cron_test.go
@@ -105,7 +105,6 @@ func TestJobsDontRunAfterStop(t *testing.T) {
 		// no job has run
 	case <-wait(wg):
 		t.FailNow()
-
 	}
 }
 
@@ -152,6 +151,68 @@ func TestRunJobTwice(t *testing.T) {
 		t.FailNow()
 	case <-wait(wg):
 	}
+}
+
+// start cron, add a job, cancel job, verify job shouldn't run.
+func TestJobsDontRunAfterCancel(t *testing.T) {
+	done := make(chan struct{})
+	cron := New()
+	cron.Start()
+	defer cron.Stop()
+
+	jobID := "testjob1"
+
+	cron.AddFuncWithJobID(Every(1*time.Second), jobID, func() { done <- struct{}{} })
+
+	cron.cancelJob(jobID)
+
+	select {
+	case <-time.After(OneSecond):
+		// no job has run
+	case <-done:
+		t.FailNow()
+	}
+}
+
+// start cron, add several job, verify jobs run
+func TestJobAndJobWithCancelRunTogether(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(3)
+	cron := New()
+
+	jobID1, jobID2 := "testjob1", "testjob2"
+
+	cron.AddFunc(Every(5*time.Minute), func() {})
+	cron.AddFunc(Every(1*time.Second), func() { wg.Done() })
+	cron.AddFuncWithJobID(Every(1*time.Second), jobID1, func() { wg.Done() })
+	cron.AddCancelingJob(Every(1*time.Second), &canceledJob{id: jobID2, wg: wg})
+	cron.AddFunc(Every(4*xtime.Week), func() {})
+
+	cron.Start()
+	defer cron.Stop()
+
+	cron.Cancel(jobID1)
+
+	select {
+	case <-time.After(OneSecond):
+		// 2 jobs run, 1 job canceled.
+	case <-wait(wg):
+		t.FailNow()
+	}
+}
+
+// canceledJob implements JobWithCancel interface
+type canceledJob struct {
+	id string
+	wg *sync.WaitGroup
+}
+
+func (job *canceledJob) JobID() string {
+	return job.id
+}
+
+func (job *canceledJob) Run() {
+	job.wg.Done()
 }
 
 // arbitrary job struct, with god's view enabled.
@@ -284,7 +345,6 @@ func TestByTimeSort(t *testing.T) {
 	}
 
 	for i, test := range tests {
-
 		got := mockEntries(getTimes(test.entries))
 		sort.Sort(byTime(got))
 
@@ -307,7 +367,6 @@ func mockEntries(nexts []time.Time) []*Entry {
 
 // getTimes splits comma-separated time.
 func getTimes(s string) []time.Time {
-
 	ts := strings.Split(s, ",")
 	ret := make([]time.Time, len(ts))
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fakeYanss/gron/xtime"
+	"github.com/fakeyanss/gron/xtime"
 )
 
 // Most test jobs scheduled to run at 1 second mark.

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/roylee0704/gron"
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fakeYanss/gron"
+	"github.com/fakeYanss/gron/xtime"
 )
 
 type printJob struct{ Msg string }
@@ -14,8 +14,19 @@ func (p printJob) Run() {
 	fmt.Println(p.Msg)
 }
 
-func main() {
+type canceledJob struct { // implements of JobWithCancel interface
+	id string
+}
 
+func (j *canceledJob) JobID() string {
+	return j.id
+}
+
+func (j *canceledJob) Run() {
+	fmt.Printf("job %s run\n", j.id)
+}
+
+func main() {
 	var (
 		daily     = gron.Every(1 * xtime.Day)
 		weekly    = gron.Every(1 * xtime.Week)
@@ -40,6 +51,16 @@ func main() {
 	// Jobs may also be added to a running Cron
 	c.Add(monthly, printBar)
 	c.AddFunc(yearly, purgeTask)
+
+	c.AddFuncWithJobID(gron.Every(1*time.Second), "job-id-1", func() {
+		fmt.Println("job-id-1 runs every second")
+	})
+	c.AddCancelingJob(gron.Every(1*time.Second), &canceledJob{id: "job-id-2"})
+	c.Start()
+
+	time.Sleep(5 * time.Second)
+	c.Cancel("job-id-1")
+	time.Sleep(5 * time.Second)
 
 	// Stop the scheduler (does not stop any jobs already running).
 	defer c.Stop()

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fakeYanss/gron"
-	"github.com/fakeYanss/gron/xtime"
+	"github.com/fakeyanss/gron"
+	"github.com/fakeyanss/gron/xtime"
 )
 
 type printJob struct{ Msg string }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/roylee0704/gron
+
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/roylee0704/gron
+module github.com/fakeYanss/gron
 
 go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/fakeYanss/gron
+module github.com/fakeyanss/gron
 
 go 1.19

--- a/schedule.go
+++ b/schedule.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/fakeYanss/gron/xtime"
+	"github.com/fakeyanss/gron/xtime"
 )
 
 // Schedule is the interface that wraps the basic Next method.

--- a/schedule.go
+++ b/schedule.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fakeYanss/gron/xtime"
 )
 
 // Schedule is the interface that wraps the basic Next method.

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fakeYanss/gron/xtime"
+	"github.com/fakeyanss/gron/xtime"
 )
 
 func TestPeriodicAtNext(t *testing.T) {

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/roylee0704/gron/xtime"
+	"github.com/fakeYanss/gron/xtime"
 )
 
 func TestPeriodicAtNext(t *testing.T) {


### PR DESCRIPTION
Defines JobWithCancel interface. Require a unique string as jobID in each job.

Sometimes we need to cancel job after it's lifecycle finished.  For example, start a monitoring job while a tcp socket alive, and cancel the monitoring job after socket closed.

So I develop the feature, support cancel job. And I defined a `JobWithCancel` interface, a `JobID()` function to index job when cancel it.

Just see this samle:

```go
type canceledJob struct { // implements of JobWithCancel interface
	id string
}
func (j *canceledJob) JobID() {
	return id
}
func (j *canceledJob) Run() {
  fmt.Println("job run")
}
c := gron.New()
c.AddFuncWithJobID(gron.Every(1*time.Second), "job-id-1", func() {
	fmt.Println("runs every second")
})
c.AddCancelingJob(Every(1*time.Second), &canceledJob{id: "job-id-2"})
c.Start()
time.Sleep(5 * time.Second)
c.Cancel("job-id-1")
c.Cancel("job-id-2")
```

lastly, I using go mod in this project. I think it is compatible in higher version of golang. If you think module is not necessary, I could remove it.